### PR TITLE
feat: make embedding model configurable

### DIFF
--- a/app/objects/model_custom_embeddings.py
+++ b/app/objects/model_custom_embeddings.py
@@ -1,5 +1,7 @@
 from typing import List
+import os
 
+import torch
 from langchain_core.embeddings import Embeddings
 from sentence_transformers import SentenceTransformer
 
@@ -12,20 +14,36 @@ class E5Embeddings(Embeddings):
 
     def __init__(
         self,
-        model_name: str = "intfloat/multilingual-e5-large",
+        model_name: str | None = None,
         device: str = "cpu",
         query_prefix: str = "query: ",
         passage_prefix: str = "passage: ",
     ):
+        if model_name is None:
+            model_name = os.getenv(
+                "EMBEDDINGS_MODEL_NAME", "intfloat/multilingual-e5-base"
+            )
         self.model = SentenceTransformer(model_name_or_path=model_name, device=device)
+        try:
+            self.model = self.model.to(dtype=torch.float16)
+        except Exception:
+            pass
         self.query_prefix = query_prefix
         self.passage_prefix = passage_prefix
         self.dim = self.model.get_sentence_embedding_dimension()  # ✅ вот это добавлено
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         prompts = [self.passage_prefix + text for text in texts]
-        return self.model.encode(prompts, convert_to_numpy=True).tolist()
+        return (
+            self.model.encode(
+                prompts, convert_to_numpy=True, normalize_embeddings=True
+            ).tolist()
+        )
 
     def embed_query(self, text: str) -> List[float]:
         prompt = self.query_prefix + text
-        return self.model.encode(prompt, convert_to_numpy=True).tolist()
+        return (
+            self.model.encode(
+                prompt, convert_to_numpy=True, normalize_embeddings=True
+            ).tolist()
+        )

--- a/app/providers/ingest.py
+++ b/app/providers/ingest.py
@@ -19,7 +19,8 @@ COLLECTION_NAME = "qa_documents"
 global_unique_hashes = set()
 
 embedding_model = E5Embeddings(
-    model_name="intfloat/multilingual-e5-large", device="cpu"
+    model_name=os.getenv("EMBEDDINGS_MODEL_NAME", "intfloat/multilingual-e5-base"),
+    device="cpu",
 )
 
 

--- a/app/providers/rag_service.py
+++ b/app/providers/rag_service.py
@@ -181,8 +181,11 @@ def initialize_components():
     _llm = HuggingFacePipeline(pipeline=_gen)
 
     print("[INIT] Embeddings (E5)...")
+    embedding_model_name = os.getenv(
+        "EMBEDDINGS_MODEL_NAME", "intfloat/multilingual-e5-base"
+    )
     _embedding_model = E5Embeddings(
-        model_name="intfloat/multilingual-e5-large",
+        model_name=embedding_model_name,
         device="cpu",
     )
 


### PR DESCRIPTION
## Summary
- allow selecting E5 embedding model via EMBEDDINGS_MODEL_NAME env var
- default to intfloat/multilingual-e5-base and encode in float16 with normalization
- wire env-based model selection into RAG service and ingest

## Testing
- `pre-commit run --files app/objects/model_custom_embeddings.py app/providers/rag_service.py app/providers/ingest.py` *(fails: command not found, unable to install pre-commit)*
- `EMBEDDINGS_MODEL_NAME=intfloat/multilingual-e5-small pytest` *(fails: ProxyError when downloading model)*

------
https://chatgpt.com/codex/tasks/task_e_68971dee47108325a3a9623b2fe3d03b